### PR TITLE
Add validation errors for connectors

### DIFF
--- a/internal/app/kafka-connect-exporter/collector/collect.go
+++ b/internal/app/kafka-connect-exporter/collector/collect.go
@@ -3,10 +3,11 @@ package collector
 import (
 	"encoding/json"
 	"fmt"
-	"github.com/prometheus/client_golang/prometheus"
-	"github.com/prometheus/common/log"
 	"io/ioutil"
 	"strings"
+
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/common/log"
 )
 
 func (c *collector) Collect(ch chan<- prometheus.Metric) {
@@ -70,6 +71,13 @@ func (c *collector) Collect(ch chan<- prometheus.Metric) {
 		ch <- prometheus.MustNewConstMetric(
 			c.isConnectorRunning, prometheus.GaugeValue, isRunning,
 			connectorStatus.Name, connectorStatus.ConsumerGroup(), strings.ToLower(connectorStatus.Connector.State), connectorStatus.Connector.WorkerId,
+		)
+
+		var validationErrorsCount float64 = float64(len(connectorStatus.ValidationErrors))
+
+		ch <- prometheus.MustNewConstMetric(
+			c.connectorValidationErrors, prometheus.GaugeValue, validationErrorsCount,
+			connectorStatus.Name, connectorStatus.ConsumerGroup(), connectorStatus.Connector.WorkerId,
 		)
 
 		for _, connectorTask := range connectorStatus.Tasks {

--- a/internal/app/kafka-connect-exporter/collector/collector.go
+++ b/internal/app/kafka-connect-exporter/collector/collector.go
@@ -1,20 +1,22 @@
 package collector
 
 import (
+	"net/url"
+	"os"
+
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/common/log"
 	"github.com/vinted/kafka-connect-exporter/internal/app/kafka-connect-exporter/client"
-	"net/url"
-	"os"
 )
 
 type collector struct {
-	client                   client.Client
-	URI                      string
-	up                       prometheus.Gauge
-	connectorsCount          prometheus.Gauge
-	isConnectorRunning       *prometheus.Desc
-	areConnectorTasksRunning *prometheus.Desc
+	client                    client.Client
+	URI                       string
+	up                        prometheus.Gauge
+	connectorsCount           prometheus.Gauge
+	isConnectorRunning        *prometheus.Desc
+	areConnectorTasksRunning  *prometheus.Desc
+	connectorValidationErrors *prometheus.Desc
 }
 
 type connectors []string
@@ -64,6 +66,12 @@ func NewCollector(uri, nameSpace, user, pass string) Collector {
 			prometheus.BuildFQName(nameSpace, "connector", "state_running"),
 			"is the connector running?",
 			[]string{"connector", "consumer_group", "state", "worker_id"},
+			nil,
+		),
+		connectorValidationErrors: prometheus.NewDesc(
+			prometheus.BuildFQName(nameSpace, "connector", "validation_errors"),
+			"connector configuration validation errors",
+			[]string{"connector", "consumer_group", "worker_id"},
 			nil,
 		),
 		areConnectorTasksRunning: prometheus.NewDesc(

--- a/internal/app/kafka-connect-exporter/collector/status.go
+++ b/internal/app/kafka-connect-exporter/collector/status.go
@@ -1,9 +1,10 @@
 package collector
 
 type status struct {
-	Name      string    `json:"name"`
-	Connector connector `json:"connector"`
-	Tasks     []task    `json:"tasks"`
+	Name             string    `json:"name"`
+	Connector        connector `json:"connector"`
+	Tasks            []task    `json:"tasks"`
+	ValidationErrors []string  `json:"validation_errors"`
 }
 
 type connector struct {


### PR DESCRIPTION
A connector can be in a RUNNING state but have an unapplied configuration change due to validation errors in the configuration.